### PR TITLE
Add ability to upload in dated sub-directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A fully featured and deeply tested [Cloudinary](https://cloudinary.com/) [Ghost]
 - Ghost version `>=1`
 - Latest Cloudinary NodeJS [SDK](https://github.com/cloudinary/cloudinary_npm)
 - Image upload, existence check & deletion
+- Ability to upload in dated sub-directories (alike Ghost default Local storage adapter `YYYY/MM`)
 - Ability to upload images into a directory
 - Ability to tag images
 - Cool [plugins](plugins)!
@@ -61,8 +62,9 @@ Here, we use the Ghost CLI to set some pre-defined values.
 
 ## Configuration
 
-Check out [configuration.sample.json](configuration.sample.json) for a complete example of Ghost integration.
+Check out [configuration.sample.json](configuration.sample.json) for a complete example.
 
+- The optional `useDatedFolder = false` to upload images in dated sub-directories (alike default Ghost Local storage adapter)
 - The `auth` property is optional if you use the `CLOUDINARY_URL` environment variable [authentification method](https://cloudinary.com/documentation/node_additional_topics#configuration_options)
 - The optional `upload` property contains Cloudinary API [upload options](https://cloudinary.com/documentation/image_upload_api_reference#upload)
 - The optional `fetch` property contains Cloudinary API [image transformation options](https://cloudinary.com/documentation/image_transformation_reference)

--- a/configuration.sample.json
+++ b/configuration.sample.json
@@ -2,6 +2,7 @@
     "storage": {
         "active": "ghost-storage-cloudinary",
         "ghost-storage-cloudinary": {
+            "useDatedFolder": false,
             "auth": {
                 "cloud_name": "",
                 "api_key": "",

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class CloudinaryAdapter extends StorageBase {
             // Kept to avoid a BCB with 2.x versions
             legacy = config.configuration || {};
 
+        this.useDatedFolder = config.useDatedFolder || false;
         this.uploadOptions = config.upload || legacy.file || {};
         this.fetchOptions = config.fetch || legacy.image || {};
         this.rjsOptions = config.rjs || null;
@@ -60,6 +61,12 @@ class CloudinaryAdapter extends StorageBase {
             {public_id: path.parse(this.getSanitizedFileName(image.name)).name}
         );
 
+        // Appends the dated folder if enabled
+        if (this.useDatedFolder) {
+            uploadOptions.folder = this.getTargetDir(uploadOptions.folder);
+        }
+
+        // Retinizes images if there is any config provided
         if (this.rjsOptions) {
             const rjs = new plugin.RetinaJS(this.uploader, uploadOptions, this.rjsOptions);
             return rjs.retinize(image);

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^4.19.0",
     "eslint-plugin-mocha": "^4.12.1",
     "istanbul": "^0.4.5",
+    "moment": "^2.21.0",
     "nock": "^9.2.3",
     "sinon": "^4.4.6"
   }


### PR DESCRIPTION
Imports default Ghost Local storage adapter behavior into Cloudinary: upload images in a dated sub-directory `YYYY/MM` 👍 

<img width="779" alt="screen shot 2018-03-22 at 8 26 35 pm" src="https://user-images.githubusercontent.com/57098/37793563-5ec713c2-2e0f-11e8-94c8-d50c167229da.png">
