### PR TITLE
Updated README.md with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A fully featured and deeply tested [Cloudinary](https://cloudinary.com/) [Ghost]
 
 ```bash
 $ yarn add ghost-storage-cloudinary@2
-$ mv node_modules/ghost-storage-cloudinary core/server/adapters/storage
+$ mv node_modules/ghost-storage-cloudinary content/adapters/storage/ghost-storage-cloudinary
 ```
 
 - Done, go configure


### PR DESCRIPTION
The change is based on the preferred adapter location as documented in https://github.com/TryGhost/Ghost/blob/5524509274bee17692e6204cde4ee51542d820cc/content/adapters/README.md#L18
It's preferred to store adapters in the content folder instead of messing with the internal structure ;)