### PR TITLE
[BC] Update plugins configuration

### DIFF
--- a/configuration.json.dist
+++ b/configuration.json.dist
@@ -19,7 +19,8 @@
                 "quality": "auto",
                 "secure": false,
                 "cdn_subdomain": true
-            }
+            },
+            "plugins": {}
         }
     },
     "imageOptimization": {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const StorageBase = require('ghost-storage-base'),
     debug = require('@tryghost/debug')('adapter'),
     cloudinary = require('cloudinary').v2,
     got = require('got'),
-    plugin = require(path.join(__dirname, '/plugins'));
+    plugins = require(path.join(__dirname, '/plugins'));
 
 class CloudinaryAdapter extends StorageBase {
 
@@ -26,7 +26,7 @@ class CloudinaryAdapter extends StorageBase {
             fetchOptions = config.fetch || legacy.image || {};
 
         this.useDatedFolder = config.useDatedFolder || false;
-        this.rjsOptions = config.rjs || null;
+        this.plugins = config.plugins || {};
         this.uploaderOptions = {
             upload: uploadOptions,
             fetch: fetchOptions
@@ -34,7 +34,7 @@ class CloudinaryAdapter extends StorageBase {
 
         debug('constructor:useDatedFolder:', this.useDatedFolder);
         debug('constructor:uploaderOptions:', this.uploaderOptions);
-        debug('constructor:rjsOptions:', this.rjsOptions);
+        debug('constructor:plugins:', this.plugins);
 
         cloudinary.config(auth);
     }
@@ -79,9 +79,9 @@ class CloudinaryAdapter extends StorageBase {
         debug('save:uploadOptions:', uploaderOptions);
 
         // Retinizes images if there is any config provided
-        if (this.rjsOptions) {
-            const rjs = new plugin.RetinaJS(this.uploader, uploaderOptions, this.rjsOptions);
-            return rjs.retinize(image);
+        if (this.plugins.retinajs) {
+            const retinajs = new plugins.RetinaJS(this.uploader, uploaderOptions, this.plugins.retinajs);
+            return retinajs.retinize(image);
         }
 
         return this.uploader(image.path, uploaderOptions, true);

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -29,7 +29,7 @@ It will generate Retina image variants for all images, including banners, author
 
 Make sure to disable [Ghost optimization feature](https://ghost.org/docs/concepts/config/#image-optimisation).
 
-In order to **activate** and configure the plugin, you need to add the `rjs` property in the [storage configuration](../configuration.sample.json):
+In order to **activate** and configure the plugin, you need to add the `retinajs` property in the [storage plugins configuration](../configuration.sample.json):
 
 ```json
 {
@@ -45,9 +45,11 @@ In order to **activate** and configure the plugin, you need to add the `rjs` pro
                 "use_filename": true
             },
             "fetch": {},
-            "rjs": {
-                "baseWidth": 960,
-                "fireForget": true
+            "plugins": {
+                "retinajs": {
+                    "baseWidth": 960,
+                    "fireForget": true
+                }
             }
         }
     }

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -2,4 +2,4 @@
 
 const path = require('path');
 
-module.exports = {RetinaJS: require(path.join(__dirname, 'retinajs'))};
+module.exports = { RetinaJS: require(path.join(__dirname, 'retinajs')) };

--- a/plugins/retinajs.js
+++ b/plugins/retinajs.js
@@ -3,20 +3,20 @@
 require('bluebird');
 
 const _ = require('lodash'),
-    sizeOf = require('image-size'),
     debug = require('@tryghost/debug')('plugins:retinajs'),
-    maxSupportedDpr = 5;
+    maxSupportedDpr = 5,
+    sizeOf = require('image-size');
 
 class RetinaJS {
 
-    constructor(uploader, uploaderOptions, rjsOptions) {
+    constructor(uploader, uploaderOptions, retinajsOptions) {
         this.uploader = uploader;
         this.uploaderOptions = uploaderOptions || {};
-        this.rjsOptions = rjsOptions || {};
-        this.rjsOptions.baseWidth = parseInt(this.rjsOptions.baseWidth, 10);
-        this.rjsOptions.fireForget = this.rjsOptions.fireForget || false;
+        this.retinajsOptions = retinajsOptions || {};
+        this.retinajsOptions.baseWidth = parseInt(this.retinajsOptions.baseWidth, 10);
+        this.retinajsOptions.fireForget = this.retinajsOptions.fireForget || false;
 
-        debug('constructor:rjsOptions', this.rjsOptions);
+        debug('constructor:retinajsOptions', this.retinajsOptions);
 
         if (typeof this.uploader !== 'function') {
             throw new TypeError('RetinaJS: uploader must be callable');
@@ -29,12 +29,12 @@ class RetinaJS {
             throw new TypeError('RetinaJS error: invalid uploaderOptions.upload.public_id. Ensure to enable Cloudinary upload.use_filename option.');
         }
 
-        if (isNaN(this.rjsOptions.baseWidth)) {
-            throw new TypeError('RetinaJS config error: invalid rjs.baseWidth option');
+        if (isNaN(this.retinajsOptions.baseWidth)) {
+            throw new TypeError('RetinaJS config error: invalid retinajs.baseWidth option');
         }
 
-        if (this.rjsOptions.baseWidth < 1) {
-            throw new RangeError('RetinaJS config error: rjs.baseWidth must be >= 1');
+        if (this.retinajsOptions.baseWidth < 1) {
+            throw new RangeError('RetinaJS config error: retinajs.baseWidth must be >= 1');
         }
     }
 
@@ -66,7 +66,7 @@ class RetinaJS {
                     finalUrl = that.sanitize(url);
 
                 // Creates subsequent variants and returns URL regardless their fulfillment status
-                if (that.rjsOptions.fireForget) {
+                if (that.retinajsOptions.fireForget) {
                     Promise.all(variants).catch((err) => {
                         console.error(new Error(`Fire&Forget RetinaJS: ${err}`));
                     });
@@ -98,7 +98,7 @@ class RetinaJS {
      */
     resolveMaxDpr(filename) {
         const dim = sizeOf(filename),
-            mdpr = Math.floor(dim.width / this.rjsOptions.baseWidth);
+            mdpr = Math.floor(dim.width / this.retinajsOptions.baseWidth);
 
         if (mdpr === 0) {
             return 1;
@@ -126,9 +126,9 @@ class RetinaJS {
             const config = JSON.parse(JSON.stringify(Object.assign({}, this.uploaderOptions))),
                 dprConfig = {
                     // Forces the image width to baseWidth
-                    width: this.rjsOptions.baseWidth,
+                    width: this.retinajsOptions.baseWidth,
                     // No scale-up!
-                    if: `iw_gt_${this.rjsOptions.baseWidth}`,
+                    if: `iw_gt_${this.retinajsOptions.baseWidth}`,
                     // Resizing method
                     crop: 'scale',
                     // The DPR will resize the image accordingly to its value

--- a/tests/adapter/save.js
+++ b/tests/adapter/save.js
@@ -251,7 +251,7 @@ describe('save', function () {
 
     it('should upload successfully with RetinaJS plugin', function (done) {
         const config = fixtures.sampleConfig();
-        config.rjs = { baseWidth: 48 };
+        config.plugins = { retinajs: { baseWidth: 48 } };
 
         cloudinaryAdapter = new CloudinaryAdapter(config);
 

--- a/tests/plugins/retinajs/constructor.js
+++ b/tests/plugins/retinajs/constructor.js
@@ -12,7 +12,7 @@ const chai = require('chai'),
 describe('constructor', function () {
     it('should fail if uploader is not callable', function (done) {
         try {
-            new RetinaJS(null, {}, {baseWidth: 1});
+            new RetinaJS(null, {}, { baseWidth: 1 });
             done('should raise an error');
         } catch (e) {
             expect(e).to.be.instanceOf(TypeError);
@@ -23,7 +23,7 @@ describe('constructor', function () {
 
     it('should fail with empty uploaderOptions', function (done) {
         try {
-            new RetinaJS(emptyFunc, {}, {baseWidth: 100});
+            new RetinaJS(emptyFunc, {}, { baseWidth: 100 });
             done('should raise an error');
         } catch (e) {
             expect(e).to.be.instanceOf(TypeError);
@@ -34,7 +34,7 @@ describe('constructor', function () {
 
     it('should fail with empty public_id uploaderOptions.upload', function (done) {
         try {
-            new RetinaJS(emptyFunc, {upload: {public_id: ''}}, {baseWidth: 100});
+            new RetinaJS(emptyFunc, { upload: { public_id: '' } }, { baseWidth: 100 });
             done('should raise an error');
         } catch (e) {
             expect(e).to.be.instanceOf(TypeError);
@@ -43,35 +43,35 @@ describe('constructor', function () {
         }
     });
 
-    it('should fail with invalid rjs.baseWidth option', function (done) {
+    it('should fail with invalid retinajs.baseWidth option', function (done) {
         try {
-            new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {});
+            new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, {});
             done('should raise an error');
         } catch (e) {
             expect(e).to.be.instanceOf(TypeError);
-            expect(e.message).to.equal('RetinaJS config error: invalid rjs.baseWidth option');
+            expect(e.message).to.equal('RetinaJS config error: invalid retinajs.baseWidth option');
             done();
         }
     });
 
-    it('should fail with non-integer rjs.baseWidth value', function (done) {
+    it('should fail with non-integer retinajs.baseWidth value', function (done) {
         try {
-            new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 'string'});
+            new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 'string' });
             done('should raise an error');
         } catch (e) {
             expect(e).to.be.instanceOf(TypeError);
-            expect(e.message).to.equal('RetinaJS config error: invalid rjs.baseWidth option');
+            expect(e.message).to.equal('RetinaJS config error: invalid retinajs.baseWidth option');
             done();
         }
     });
 
-    it('should fail with rjs.baseWidth value < 1', function (done) {
+    it('should fail with retinajs.baseWidth value < 1', function (done) {
         try {
-            new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: -12});
+            new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: -12 });
             done('should raise an error');
         } catch (e) {
             expect(e).to.be.instanceOf(RangeError);
-            expect(e.message).to.equal('RetinaJS config error: rjs.baseWidth must be >= 1');
+            expect(e.message).to.equal('RetinaJS config error: retinajs.baseWidth must be >= 1');
             done();
         }
     });

--- a/tests/plugins/retinajs/generateDprConfigs.js
+++ b/tests/plugins/retinajs/generateDprConfigs.js
@@ -10,8 +10,8 @@ const chai = require('chai'),
 
 describe('generateDprConfigs', function () {
     it('should return 1 config when dpr = 1 and have public_id untouched', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 200}),
-            dprConfig = rjs.generateDprConfigs(1);
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 200 }),
+            dprConfig = retinajs.generateDprConfigs(1);
 
         expect(dprConfig).to.have.lengthOf(1);
         expect(dprConfig[0].upload.public_id).to.equal('foo');
@@ -29,8 +29,8 @@ describe('generateDprConfigs', function () {
                     tags: ['test']
                 }
             },
-            rjs = new RetinaJS(emptyFunc, uploaderConfig, {baseWidth: 200}),
-            dprConfig = rjs.generateDprConfigs(3);
+            retinajs = new RetinaJS(emptyFunc, uploaderConfig, { baseWidth: 200 }),
+            dprConfig = retinajs.generateDprConfigs(3);
 
         expect(dprConfig).to.have.lengthOf(3);
 
@@ -52,9 +52,9 @@ describe('generateDprConfigs', function () {
     });
 
     it('should throw an error when dpr < 1', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 1});
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 1 });
         try {
-            rjs.generateDprConfigs(0);
+            retinajs.generateDprConfigs(0);
             done('should raise an error');
         } catch (e) {
             expect(e.message).to.equal('Unexpected dpr value: 0');

--- a/tests/plugins/retinajs/resolveMaxDpr.js
+++ b/tests/plugins/retinajs/resolveMaxDpr.js
@@ -10,58 +10,58 @@ const chai = require('chai'),
 
 describe('resolveMaxDpr', function () {
     it('should return 1 when image width = baseWidth', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 500}),
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 500 }),
             image = path.join(__dirname, '500x250.png');
 
-        expect(rjs.resolveMaxDpr(image)).to.equal(1);
+        expect(retinajs.resolveMaxDpr(image)).to.equal(1);
         done();
     });
 
     it('should return 1 when image width < baseWidth', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 600}),
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 600 }),
             image = path.join(__dirname, '500x250.png');
 
-        expect(rjs.resolveMaxDpr(image)).to.equal(1);
+        expect(retinajs.resolveMaxDpr(image)).to.equal(1);
         done();
     });
 
     it('should return 2 when image width = 2 * baseWidth', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 250}),
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 250 }),
             image = path.join(__dirname, '500x250.png');
 
-        expect(rjs.resolveMaxDpr(image)).to.equal(2);
+        expect(retinajs.resolveMaxDpr(image)).to.equal(2);
         done();
     });
 
     it('should return 2 when image width = 2.5 * baseWidth', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 200}),
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 200 }),
             image = path.join(__dirname, '500x250.png');
 
-        expect(rjs.resolveMaxDpr(image)).to.equal(2);
+        expect(retinajs.resolveMaxDpr(image)).to.equal(2);
         done();
     });
 
     it('should return 5 when image width = 5 * baseWidth', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 100}),
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 100 }),
             image = path.join(__dirname, '500x250.png');
 
-        expect(rjs.resolveMaxDpr(image)).to.equal(5);
+        expect(retinajs.resolveMaxDpr(image)).to.equal(5);
         done();
     });
 
     it('should return 5 when image width = 10 * baseWidth', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 50}),
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 50 }),
             image = path.join(__dirname, '500x250.png');
 
-        expect(rjs.resolveMaxDpr(image)).to.equal(5);
+        expect(retinajs.resolveMaxDpr(image)).to.equal(5);
         done();
     });
 
     it('should throw an error if image is not found', function (done) {
-        const rjs = new RetinaJS(emptyFunc, {upload: {public_id: 'foo'}}, {baseWidth: 50});
+        const retinajs = new RetinaJS(emptyFunc, { upload: { public_id: 'foo' } }, { baseWidth: 50 });
 
         try {
-            rjs.resolveMaxDpr('./ghost.png');
+            retinajs.resolveMaxDpr('./ghost.png');
             done('should raise an error');
         } catch (e) {
             done();

--- a/tests/plugins/retinajs/retinize.js
+++ b/tests/plugins/retinajs/retinize.js
@@ -20,12 +20,12 @@ describe('retinize', function () {
 
     it('should retinize successfully (dpr1)', function (done) {
         const image = fixtures.mockImage,
-            config = {upload: {public_id: image.name}},
-            rjs = new RetinaJS(uploader, config, {baseWidth: 500});
+            config = { upload: { public_id: image.name } },
+            retinajs = new RetinaJS(uploader, config, { baseWidth: 500 });
 
         uploader.withArgs(image.path, sinon.match(config), true).resolves('http://example.com/500x250.png');
 
-        rjs.retinize(image).then(function (url) {
+        retinajs.retinize(image).then(function (url) {
             expect(url).to.equal('http://example.com/500x250.png');
             expect(uploader.callCount).to.equal(1, 'Uploader should have been called 1 time');
             done();
@@ -37,12 +37,12 @@ describe('retinize', function () {
 
     it('should return an error when an error occurs (dpr1)', function (done) {
         const image = fixtures.mockImage,
-            config = {upload: {public_id: image.name}},
-            rjs = new RetinaJS(uploader, config, {baseWidth: 500});
+            config = { upload: { public_id: image.name } },
+            retinajs = new RetinaJS(uploader, config, { baseWidth: 500 });
 
         uploader.withArgs(image.path, sinon.match(config), true).rejects(new Error('some error occurred'));
 
-        rjs.retinize(image).then(function () {
+        retinajs.retinize(image).then(function () {
             done('should raise an error');
         }).
             catch(function (err) {
@@ -54,13 +54,13 @@ describe('retinize', function () {
 
     it('should retinize successfully (dpr4/sync)', function (done) {
         const image = fixtures.mockImage,
-            config = {upload: {public_id: `${image.name}@4x`}},
-            rjs = new RetinaJS(uploader, {upload: {public_id: image.name}}, {baseWidth: 125});
+            config = { upload: { public_id: `${image.name}@4x` } },
+            retinajs = new RetinaJS(uploader, { upload: { public_id: image.name } }, { baseWidth: 125 });
 
         uploader.withArgs(image.path, sinon.match(config), true).resolves('http://example.com/500x250.png');
         uploader.withArgs('http://example.com/500x250.png', sinon.match.object, false).resolves();
 
-        rjs.retinize(image).then(function (url) {
+        retinajs.retinize(image).then(function (url) {
             expect(url).to.equal('http://example.com/500x250.png');
             expect(uploader.callCount).to.equal(4, 'Uploader should have been called 4 times');
             done();
@@ -72,14 +72,14 @@ describe('retinize', function () {
 
     it('should return an error when an error occurs (dpr4/sync)', function (done) {
         const image = fixtures.mockImage,
-            config3 = {upload: {public_id: `${image.name}@3x`}},
-            config4 = {upload: {public_id: `${image.name}@4x`}},
-            rjs = new RetinaJS(uploader, {upload: {public_id: image.name}}, {baseWidth: 125});
+            config3 = { upload: { public_id: `${image.name}@3x` } },
+            config4 = { upload: { public_id: `${image.name}@4x` } },
+            retinajs = new RetinaJS(uploader, { upload: { public_id: image.name } }, { baseWidth: 125 });
 
         uploader.withArgs(image.path, sinon.match(config4), true).resolves('http://example.com/500x250.png');
         uploader.withArgs('http://example.com/500x250.png', sinon.match(config3), false).rejects(new Error('Oops!'));
 
-        rjs.retinize(image).then(function () {
+        retinajs.retinize(image).then(function () {
             done('should raise an error');
         }).
             catch(function (err) {
@@ -91,8 +91,8 @@ describe('retinize', function () {
 
     it('should retinize successfully (dpr4/async)', function (done) {
         const image = fixtures.mockImage,
-            config = {upload: {public_id: `${image.name}@4x`}},
-            rjs = new RetinaJS(uploader, {upload: {public_id: image.name}}, {
+            config = { upload: { public_id: `${image.name}@4x` } },
+            retinajs = new RetinaJS(uploader, { upload: { public_id: image.name } }, {
                 baseWidth: 125,
                 fireForget: true
             });
@@ -100,7 +100,7 @@ describe('retinize', function () {
         uploader.withArgs(image.path, sinon.match(config), true).resolves('http://example.com/500x250.png');
         uploader.withArgs('http://example.com/500x250.png', sinon.match.object, false).resolves();
 
-        rjs.retinize(image).then(function (url) {
+        retinajs.retinize(image).then(function (url) {
             expect(url).to.equal('http://example.com/500x250.png');
             expect(uploader.callCount).to.equal(4, 'Uploader should have been called 4 times');
             done();
@@ -112,9 +112,9 @@ describe('retinize', function () {
 
     it('should return an error when a retinize errors at first dpr (dpr4/async)', function (done) {
         const image = fixtures.mockImage,
-            config3 = {upload: {public_id: `${image.name}@3x`}},
-            config4 = {upload: {public_id: `${image.name}@4x`}},
-            rjs = new RetinaJS(uploader, {upload: {public_id: image.name}}, {
+            config3 = { upload: { public_id: `${image.name}@3x` } },
+            config4 = { upload: { public_id: `${image.name}@4x` } },
+            retinajs = new RetinaJS(uploader, { upload: { public_id: image.name } }, {
                 baseWidth: 125,
                 fireForget: true
             });
@@ -122,7 +122,7 @@ describe('retinize', function () {
         uploader.withArgs(image.path, sinon.match(config4), true).rejects(new Error('Oops!'));
         uploader.withArgs('http://example.com/500x250.png', sinon.match(config3), false).resolves();
 
-        rjs.retinize(image).then(function () {
+        retinajs.retinize(image).then(function () {
             done('should raise an error');
         }).
             catch(function (err) {
@@ -134,9 +134,9 @@ describe('retinize', function () {
 
     it('should not return an error when a retinize error occurs after the first dpr (dpr4/async)', function (done) {
         const image = fixtures.mockImage,
-            config3 = {upload: {public_id: `${image.name}@3x`}},
-            config4 = {upload: {public_id: `${image.name}@4x`}},
-            rjs = new RetinaJS(uploader, {upload: {public_id: image.name}}, {
+            config3 = { upload: { public_id: `${image.name}@3x` } },
+            config4 = { upload: { public_id: `${image.name}@4x` } },
+            retinajs = new RetinaJS(uploader, { upload: { public_id: image.name } }, {
                 baseWidth: 125,
                 fireForget: true
             });
@@ -144,7 +144,7 @@ describe('retinize', function () {
         uploader.withArgs(image.path, sinon.match(config4), true).resolves('http://example.com/500x250.png');
         uploader.withArgs('http://example.com/500x250.png', sinon.match(config3), false).rejects('Oops!');
 
-        rjs.retinize(image).then(function (url) {
+        retinajs.retinize(image).then(function (url) {
             expect(url).to.equal('http://example.com/500x250.png');
             expect(uploader.callCount).to.equal(4, 'Uploader should have been called 4 times');
             done();

--- a/tests/plugins/retinajs/sanitize.js
+++ b/tests/plugins/retinajs/sanitize.js
@@ -6,17 +6,17 @@ const chai = require('chai'),
     RetinaJS = require(path.join(__dirname, '../../../plugins')).RetinaJS;
 
 describe('sanitize', function () {
-    it('should remove rjs identifier', function (done) {
+    it('should remove retinajs identifier', function (done) {
         const tests = [
                 ['input.ext', 'input.ext'],
                 ['foo.ext', 'foo@1x.ext'],
                 ['encoded.ext', 'encoded%403x.ext'],
                 ['foo@2x.ext', 'foo@2x@1x.ext']
             ],
-            rjs = new RetinaJS(function(){/* Do nothing */ }, {upload: {public_id: 'foo'}}, {baseWidth: 1});
+            retinajs = new RetinaJS(function () {/* Do nothing */ }, { upload: { public_id: 'foo' } }, { baseWidth: 1 });
 
         for (const [expected, input] of tests) {
-            expect(rjs.sanitize(input)).to.equal(expected);
+            expect(retinajs.sanitize(input)).to.equal(expected);
         }
         done();
     });


### PR DESCRIPTION
In order to prepare new plugins, the plugin configuration has changed. RetinaJS configuration was in `ghost-storage-cloudinary.rjs` JSON property while it's now wrapped into a `plugins` object.

Before:

```json
{
    "storage": {
        "active": "ghost-storage-cloudinary",
        "ghost-storage-cloudinary": {
            "rjs": {
                "baseWidth": 960,
                "fireForget": true
            }
        }
    }
}
```

Now:

```json
{
    "storage": {
        "active": "ghost-storage-cloudinary",
        "ghost-storage-cloudinary": {
            "plugins": {
                "retinajs": {
                    "baseWidth": 960,
                    "fireForget": true
                }
            }
        }
    }
}
```