### PR TITLE
Added vanity URL configuration, example config, and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A fully featured and deeply tested [Cloudinary](https://cloudinary.com/) [Ghost]
 - Ability to upload in dated sub-directories (alike first Ghost default Local storage adapter `YYYY/MM`)
 - Ability to upload images into a specific directory
 - Ability to tag images
+- Ability to apply a vanity CDN URL to proxy requests to Cloudinary (works with [this](https://github.com/wesbos/cloudflare-cloudinary-proxy))
 - Cool [plugins](plugins)!
 
 ## Installation

--- a/configuration.json.dist
+++ b/configuration.json.dist
@@ -20,6 +20,9 @@
                 "secure": false,
                 "cdn_subdomain": true
             },
+            "vanity": {
+                "baseUrl": ""
+            },
             "plugins": {}
         }
     },

--- a/index.js
+++ b/index.js
@@ -31,10 +31,15 @@ class CloudinaryAdapter extends StorageBase {
             upload: uploadOptions,
             fetch: fetchOptions
         };
+        this.vanityOptions = {
+            ...config.vanity,
+            cloudName: auth.cloud_name
+        };
 
         debug('constructor:useDatedFolder:', this.useDatedFolder);
         debug('constructor:uploaderOptions:', this.uploaderOptions);
         debug('constructor:plugins:', this.plugins);
+        debug('constructor:vanityOptions:', this.vanityOptions);
 
         cloudinary.config(auth);
     }
@@ -82,6 +87,15 @@ class CloudinaryAdapter extends StorageBase {
         if (this.plugins.retinajs) {
             const retinajs = new plugins.RetinaJS(this.uploader, uploaderOptions, this.plugins.retinajs);
             return retinajs.retinize(image);
+        }
+
+        // Apply vanity options if there is any config provided
+        if (this.vanityOptions && this.vanityOptions.baseUrl) {
+            const clRegex = new RegExp(`^https?:\\/\\/res(-\\d*)?\\.cloudinary\\.com(\\/${this.vanityOptions.cloudName})?(\\/image\\/upload)?\/`);
+            return this.uploader(image.path, uploaderOptions, true)
+                .then((cloudinaryUrl) => {
+                    return cloudinaryUrl.replace(clRegex, this.vanityOptions.baseUrl);
+                });
         }
 
         return this.uploader(image.path, uploaderOptions, true);


### PR DESCRIPTION
This PR adds the ability to set a vanity URL which proxies requests to Cloudinary. In my use case, I am leveraging a Cloudflare worker that proxies requests to Cloudinary to reduce Cloudinary bandwidth consumption and adds a nicer-looking vanity URL. See this project for the Cloudflare setup: [wesbos/cloudflare-cloudinary-proxy](https://github.com/wesbos/cloudflare-cloudinary-proxy).

With this configured, an image that would normally have been saved into Ghost as:
`https://res-1.cloudinary.com/mycloudname/image/upload/q_85,w_1200/v1/cool.jpg`

Now becomes:
`https://images.mydomain.com/upload/q_85,w_1200/v1/cool.jpg`

With this configuration set:
```
"vanity": {
    "baseUrl": "https://images.mydomain.com/upload/"
},
```

No hard feelings if you don't want to merge this PR since my use case may be an anomaly, but I will be using this in my project so I thought I'd send in a PR.

Thank you for creating and maintaining this project. I've been using it for a couple years and it has worked wonderfully! 😀