### PR TITLE
fix: rename getSanitizedFileName to sanitizeFileName and update deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ class CloudinaryAdapter extends StorageBase {
         if (uploaderOptions.upload.use_filename !== 'undefined' && uploaderOptions.upload.use_filename) {
             Object.assign(
                 uploaderOptions.upload,
-                { public_id: path.parse(this.getSanitizedFileName(image.name)).name }
+                { public_id: path.parse(this.sanitizeFileName(image.name)).name }
             );
         }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@tryghost/errors": "^1.2.18",
     "bluebird": "^3.7.0",
     "cloudinary": "^1.30.0",
-    "ghost-storage-base": "^1.0.0",
+    "ghost-storage-base": "^1.1.1",
     "got": "^11.0",
     "image-size": "^1.0.1",
     "lodash": "^4.17.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,10 +1878,10 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-ghost-storage-base@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ghost-storage-base/-/ghost-storage-base-1.0.0.tgz#931289d310ad59fc80e2be01a81235cc3a76e75a"
-  integrity sha512-qIW6pny/wWKjrbRmXVNis9i7856AMR5/NZmnLTrKbA0KIEnA9K/fhkj7ISnSyTYfBv17sFsC23eJfvj6dDgZrQ==
+ghost-storage-base@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ghost-storage-base/-/ghost-storage-base-1.1.1.tgz#63caec4af9cb2f5cd0271cc87bf85cbadd135de8"
+  integrity sha512-MRokcZctPKO/Oonn2W55dYNZRPn75lBoSdoOc1BtwL7wm/Sq/Qx7ovx1H5seZhCReFs8QOeUXvX9dXuguBSnnQ==
   dependencies:
     moment "2.27.0"
 


### PR DESCRIPTION
The current implementation is broken on the latest ghost `v5.110.0`. This change is needed due to the refactoring of the filename  sanitization function made here https://github.com/TryGhost/Ghost-Storage-Base/pull/70
- Rename method to match refactor of upstream ghost-storage-base
- Upgrade ghost-storage-base from 1.0.0 to 1.1.1